### PR TITLE
Create zeppelin and livy users in HDP

### DIFF
--- a/isilon_create_users.sh
+++ b/isilon_create_users.sh
@@ -164,7 +164,7 @@ case "$DIST" in
     "hwx")
         SUPER_USERS="hdfs mapred yarn hbase storm falcon tracer"
         SUPER_GROUPS="hadoop"
-        REQUIRED_USERS="$SUPER_USERS tez hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop anonymous spark mahout ranger kms atlas ams kafka"
+        REQUIRED_USERS="$SUPER_USERS tez hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop anonymous spark mahout ranger kms atlas ams kafka zeppelin livy"
         REQUIRED_GROUPS="$REQUIRED_USERS $SUPER_GROUPS"
         ;;
     "bi")


### PR DESCRIPTION
HDP 2.5 will require two new service users: `zeppelin` and `livy`.

Apache Zeppelin has been available as a [technical preview](http://hortonworks.com/hadoop-tutorial/apache-zeppelin-hdp-2-4/) since HDP 2.3. Apache Livy has been [available as well](https://community.hortonworks.com/articles/34424/apache-zeppelin-on-hdp-242.html).