### PR TITLE
Create default admin user for Ambari views

### DIFF
--- a/isilon_create_users.sh
+++ b/isilon_create_users.sh
@@ -165,6 +165,9 @@ case "$DIST" in
         SUPER_USERS="hdfs mapred yarn hbase storm falcon tracer"
         SUPER_GROUPS="hadoop"
         REQUIRED_USERS="$SUPER_USERS tez hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop anonymous spark mahout ranger kms atlas ams kafka"
+        if [ zone != "System" ]; then
+          REQUIRED_USERS = "$REQUIRED_USERS admin"
+        fi
         REQUIRED_GROUPS="$REQUIRED_USERS $SUPER_GROUPS"
         ;;
     "bi")


### PR DESCRIPTION
This creates the `admin` user to enable [Ambari views](http://docs.hortonworks.com/HDPDocuments/Ambari-2.2.2.0/bk_ambari_views_guide/content/_setup_HDFS_user_directory.html) with the default Ambari admin user. The user name `admin` conflicts with a pre-existing user in OneFS in the `System` zone, so this change only creates when not System.