### PR TITLE
Add more HDP 2.5 users and correct syntax

### DIFF
--- a/isilon_create_users.sh
+++ b/isilon_create_users.sh
@@ -162,7 +162,7 @@ case "$DIST" in
         REQUIRED_GROUPS="$REQUIRED_USERS $SUPER_GROUPS sqoop"
         ;;
     "hwx")
-        SUPER_USERS="hdfs mapred yarn hbase storm falcon tracer tez hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop spark mahout ranger kms atlas ams kafka zeppelin livy""
+        SUPER_USERS="hdfs mapred yarn hbase storm falcon tracer tez hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop spark mahout ranger kms atlas ams kafka zeppelin livy logsearch logsearch-solr activity_analyzer activity_explorer"
         SUPER_GROUPS="hadoop"
         REQUIRED_USERS="$SUPER_USERS anonymous" 
 	if [ zone != "System" ]; then


### PR DESCRIPTION
Removed an extra closing quote that worked its way into the HWX
super_users list.

Also added additional users needed for Log Search and SmartSense in
Ambari 2.4 (HDP 2.5).