### PR TITLE
Fix admin user creation

### DIFF
--- a/isilon_create_users.sh
+++ b/isilon_create_users.sh
@@ -173,8 +173,8 @@ case "$DIST" in
         SUPER_USERS="hdfs mapred yarn hbase storm falcon tracer tez hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop spark mahout ranger kms atlas ams kafka zeppelin livy logsearch logsearch-solr activity_analyzer activity_explorer"
         SUPER_GROUPS="hadoop"
         REQUIRED_USERS="$SUPER_USERS anonymous" 
-	if [ zone != "System" ]; then
-          REQUIRED_USERS = "$REQUIRED_USERS admin"
+	if [ "$ZONE" != "System" ]; then
+          REQUIRED_USERS="$REQUIRED_USERS admin"
         fi
         REQUIRED_GROUPS="$REQUIRED_USERS $SUPER_GROUPS"
         ;;


### PR DESCRIPTION
Corrects syntax errors in the zone check and in the user assignment.

Fixes #6

Tests:
```
roket-admin-1# isi zone create --name z1 --create-path --path /ifs/z1
roket-admin-1# bash ~/isilon_create_users.sh --dist hwx --zone z1
Info: Hadoop distribution:  hwx
Info: will put users in zone:  z1
Info: HDFS root:  /ifs/z1
Info: passwd file: z1.passwd
Info: group file: z1.group
SUCCESS -- Hadoop users created successfully!
roket-admin-1# bash ~/isilon_create_users.sh --dist hwx --zone System
Info: Hadoop distribution:  hwx
Info: will put users in zone:  System
Info: HDFS root:  /ifs
Info: passwd file: System.passwd
Info: group file: System.group
SUCCESS -- Hadoop users created successfully!
Done!
```

Confirmed accounts, particularly admin account created properly in both zones. (admin account not created in System zone; already exists)