### PR TITLE
Add HTTP user to all Hive to proxy

### DIFF
--- a/isilon_create_users.sh
+++ b/isilon_create_users.sh
@@ -170,7 +170,7 @@ case "$DIST" in
         REQUIRED_GROUPS="$REQUIRED_USERS $SUPER_GROUPS sqoop"
         ;;
     "hwx")
-        SUPER_USERS="hdfs mapred yarn hbase storm falcon tracer tez hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop spark mahout ranger kms atlas ams kafka zeppelin livy logsearch logsearch-solr activity_analyzer activity_explorer"
+        SUPER_USERS="hdfs mapred yarn hbase storm falcon tracer tez hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop spark mahout ranger kms atlas ams kafka zeppelin livy logsearch logsearch-solr activity_analyzer activity_explorer HTTP"
         SUPER_GROUPS="hadoop"
         REQUIRED_USERS="$SUPER_USERS anonymous" 
 	if [ "$ZONE" != "System" ]; then


### PR DESCRIPTION
In Ambari 2.4, the Hive service check when Kerberized verifies hadoop.proxyuser.HTTP.groups
by having the SPNEGO principal attempt to act on behalf of ambari-qa.

So, an HTTP user is needed on OneFS. And then a proxyuser needs to be configured. This
takes care of the first part. The implementation guide needs to be updated for proxyuser.