### PR TITLE
Add root proxyuser for Hive View

### DIFF
--- a/isilon_create_users.sh
+++ b/isilon_create_users.sh
@@ -180,7 +180,7 @@ case "$DIST" in
           REQUIRED_USERS="$REQUIRED_USERS admin"
         fi
         REQUIRED_GROUPS="$REQUIRED_USERS $SUPER_GROUPS"
-        PROXY_SUPER="yarn livy hcat hbase flume hive oozie"
+        PROXY_SUPER="yarn livy hcat hbase flume hive oozie root"
         PROXY_USERONLY="HTTP knox"
         SMOKE_USER="ambari-qa"
         ;;


### PR DESCRIPTION
Fixes #11 

The user that is running the ambari-server process (usually
root) needs to be able to proxy as the user signed into Ambari.

This is described in Ambari View documentation eg for 2.4.1.0,
https://docs.hortonworks.com/HDPDocuments/Ambari-2.4.1.0/bk_ambari-views/content/configuring_your_cluster.html

Admins will still need to add the Ambari user as a member of
this proxyuser, per the ECN instructions,
http://community.emc.com/community/products/isilon/blog/2016/08/16/configuring-ambari-hive-view-with-onefs