### PR TITLE
Update isilon_create_users.sh

### DIFF
--- a/isilon_create_users.sh
+++ b/isilon_create_users.sh
@@ -166,7 +166,7 @@ case "$DIST" in
     "cdh")
         SUPER_USERS="hdfs mapred yarn HTTP hbase"
         SUPER_GROUPS="hadoop supergroup"
-        REQUIRED_USERS="$SUPER_USERS cloudera-scm accumulo flume hbase hive httpfs hue apache impala kafka kms keytrustee kudu llama oozie solr spark sentry sqoop sqoop2 zookeeper anonymous cmjobuser"
+        REQUIRED_USERS="$SUPER_USERS hive impala hue cloudera-scm accumulo flume httpfs apache kafka kms keytrustee kudu llama oozie solr spark sentry sqoop sqoop2 zookeeper anonymous cmjobuser"
         REQUIRED_GROUPS="$REQUIRED_USERS $SUPER_GROUPS"
         PROXY_SUPER="impala flume hive hue oozie mapred"
         PROXY_USERONLY="HTTP"
@@ -175,24 +175,24 @@ case "$DIST" in
     "hwx")
         SUPER_USERS="hdfs mapred yarn hbase storm falcon tracer tez hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop spark mahout ranger kms atlas ams kafka zeppelin livy logsearch infra-solr activity_analyzer activity_explorer HTTP knox ambari-server"
         SUPER_GROUPS="hadoop"
-        REQUIRED_USERS="$SUPER_USERS anonymous" 
-	if [ "$ZONE" != "System" ]; then
+        REQUIRED_USERS="$SUPER_USERS anonymous"
+        if [ "$ZONE" != "System" ]; then
           REQUIRED_USERS="$REQUIRED_USERS admin"
         fi
         REQUIRED_GROUPS="$REQUIRED_USERS $SUPER_GROUPS"
-        PROXY_SUPER="yarn livy hcat hbase flume hive oozie root"
+        PROXY_SUPER="yarn livy hcat hbase flume hive oozie"
         PROXY_USERONLY="HTTP ambari-server knox"
         SMOKE_USER="ambari-qa"
         ;;
     "bi")
-        SUPER_USERS="hdfs mapred hbase knox uiuser dsmadmin bigsheets ambari-qa rrdcached hive yarn hcat bigsql tauser bigr flume nagios solr spark sqoop zookeeper oozie bighome ams livy logsearch infra-solr activity_analyzer activity_explorer HTTP knox ambari-server" 
-	SUPER_GROUPS="hadoop"
+        SUPER_USERS="hdfs mapred yarn hbase storm falcon tracer hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop spark mahout ranger kms atlas ams kafka zeppelin livy logsearch infra-solr acctivity_analyzer activity_explorer HTTP knox ambari-server uiuser dsmadmin bigsheets rrdcached bigsql tauser bigr solr bighome"
+        SUPER_GROUPS="hadoop"
         REQUIRED_USERS="$SUPER_USERS anonymous"
-	if [ "$ZONE" != "System" ]; then
+        if [ "$ZONE" != "System" ]; then
           REQUIRED_USERS="$REQUIRED_USERS admin"
         fi
         REQUIRED_GROUPS="$REQUIRED_USERS $SUPER_GROUPS"
-        PROXY_SUPER="yarn livy hcat hbase flume hive oozie root"
+        PROXY_SUPER="yarn livy hcat hbase flume hive oozie"
         PROXY_USERONLY="HTTP ambari-server knox"
         SMOKE_USER="ambari-qa"
         ;;
@@ -282,35 +282,32 @@ done
 # Special cases
 case "$DIST" in
     "cdh")
-        #Deal with special cases on Isilon 
-	isi auth groups modify sqoop$CLUSTER_NAME --add-user sqoop2$CLUSTER_NAME --zone $ZONE
+        #Deal with special cases on Isilon
+        isi auth groups modify sqoop$CLUSTER_NAME --add-user sqoop2$CLUSTER_NAME --zone $ZONE
         [ $? -ne 0 ] && addError "Could not add user sqoop2$CLUSTER_NAME to sqoop$CLUSTER_NAME group in zone $ZONE"
         isi auth groups modify hive$CLUSTER_NAME --add-user impala$CLUSTER_NAME --zone $ZONE
-        [ $? -ne 0 ] && addError "Could not add user implala$CLUSTER_NAME to hive$CLUSTER_NAME group in zone $ZONE"
-	isi auth groups modify hadoop$CLUSTER_NAME --add-user hbase$CLUSTER_NAME --zone $ZONE
-        [ $? -ne 0 ] && addError "Could not add user hbase$CLUSTER_NAME to hadoop$CLUSTER_NAME group in zone $ZONE"
-	
-	#Set some varliables to take these special case group assignments to the group file
+        [ $? -ne 0 ] && addError "Could not add user impala$CLUSTER_NAME to hive$CLUSTER_NAME group in zone $ZONE"
+
+        #Set some varliables to take these special case group assignments to the group file
         sqp=`grep sqoop$CLUSTER_NAME $grpfile`
         hve=`grep hive$CLUSTER_NAME $grpfile`
 
-	#manipulate the group file for special cases
+        #manipulate the group file for special cases
         sed -i .bak /$sqp/d $grpfile
-        echo "$sqp,sqoop2" | cat >> $grpfile
+        echo "$sqp,sqoop2$CLUSTER_NAME" | cat >> $grpfile
         [ $? -ne 0 ] && addError "Could not add user sqoop2$CLUSTER_NAME to sqoop$CLUSTER_NAME group in $grpfile"
         sed -i .bak /$hve/d $grpfile
-        echo "$hve,impala" | cat >> $grpfile
+        echo "$hve,impala$CLUSTER_NAME" | cat >> $grpfile
         [ $? -ne 0 ] && addError "Could not add user impala$CLUSTER_NAME to hive$CLUSTER_NAME group in $grpfile"
         ;;
     "bi")
-        isi auth groups modify users$CLUSTER_NAME --add-user hive$CLUSTER_NAME --zone $ZONE
-        [ $? -ne 0 ] && addError "Could not add user hive$CLUSTER_NAME to users$CLUSTER_NAME group in zone $ZONE"
         isi auth groups modify hcat$CLUSTER_NAME --add-user hive$CLUSTER_NAME --zone $ZONE
         [ $? -ne 0 ] && addError "Could not add user hive$CLUSTER_NAME to hcat$CLUSTER_NAME group in zone $ZONE"
         hct=`grep hcat$CLUSTER_NAME: $grpfile`
         sed -i .bak /$hct/d $grpfile
         echo "$hct,hive$CLUSTER_NAME" | cat >> $grpfile
         [ $? -ne 0 ] && addError "Could not add user hive$CLUSTER_NAME to hcat$CLUSTER_NAME group in $grpfile"
+
         isi auth groups modify knox$CLUSTER_NAME --add-user kafka$CLUSTER_NAME --zone $ZONE
         [ $? -ne 0 ] && addError "Could not add user kafka$CLUSTER_NAME to knox$CLUSTER_NAME group in zone $ZONE"
         knx=`grep knox$CLUSTER_NAME: $grpfile`


### PR DESCRIPTION
```
This version of the script successfully addressed the open issued posted by David Tucker.

Test results shown below:

hop-isi-c-1# bash ./icu2.sh --dist cdh --zone cdh --append-cluster-name test
Info: Hadoop distribution:  cdh
Info: will put users in zone:  cdh
Info: will add clustername to end of usernames: -test
Info: HDFS root:  /ifs/cdh
Info: passwd file: cdh.passwd
Info: group file: cdh.group
SUCCESS -- Hadoop users created successfully!
Done!

hop-isi-c-1# cat cdh.group
# use this file to add to the group file of your clients
hdfs-test:x:1000:
mapred-test:x:1001:
yarn-test:x:1002:
HTTP-test:x:1003:
hbase-test:x:1004:
impala-test:x:1006:
hue-test:x:1007:
cloudera-scm-test:x:1008:
accumulo-test:x:1009:
flume-test:x:1010:
httpfs-test:x:1011:
apache-test:x:1012:
kafka-test:x:1013:
kms-test:x:1014:
keytrustee-test:x:1015:
kudu-test:x:1016:
llama-test:x:1017:
oozie-test:x:1018:
solr-test:x:1019:
spark-test:x:1020:
sentry-test:x:1021:
sqoop2-test:x:1023:
zookeeper-test:x:1024:
anonymous-test:x:1025:
cmjobuser-test:x:1026:
hadoop-test:x:1027:,hdfs-test,mapred-test,yarn-test,HTTP-test,hbase-test
supergroup-test:x:1028:,hdfs-test,mapred-test,yarn-test,HTTP-test,hbase-test
sqoop-test:x:1022:,sqoop2-test
hive-test:x:1005:,impala-test

hop-isi-c-1# cat cdh.passwd
# use this file to add to the passwd file of your clients hdfs-test:x:1000:1000:hadoop-svc-account:/home/hdfs-test:/bin/bash
mapred-test:x:1001:1001:hadoop-svc-account:/home/mapred-test:/bin/bash
yarn-test:x:1002:1002:hadoop-svc-account:/home/yarn-test:/bin/bash
HTTP-test:x:1003:1003:hadoop-svc-account:/home/HTTP-test:/bin/bash
hbase-test:x:1004:1004:hadoop-svc-account:/home/hbase-test:/bin/bash
hive-test:x:1005:1005:hadoop-svc-account:/home/hive-test:/bin/bash
impala-test:x:1006:1006:hadoop-svc-account:/home/impala-test:/bin/bash
hue-test:x:1007:1007:hadoop-svc-account:/home/hue-test:/bin/bash
cloudera-scm-test:x:1008:1008:hadoop-svc-account:/home/cloudera-scm-test:/bin/bash
accumulo-test:x:1009:1009:hadoop-svc-account:/home/accumulo-test:/bin/bash
flume-test:x:1010:1010:hadoop-svc-account:/home/flume-test:/bin/bash
httpfs-test:x:1011:1011:hadoop-svc-account:/home/httpfs-test:/bin/bash
apache-test:x:1012:1012:hadoop-svc-account:/home/apache-test:/bin/bash
kafka-test:x:1013:1013:hadoop-svc-account:/home/kafka-test:/bin/bash
kms-test:x:1014:1014:hadoop-svc-account:/home/kms-test:/bin/bash
keytrustee-test:x:1015:1015:hadoop-svc-account:/home/keytrustee-test:/bin/bash
kudu-test:x:1016:1016:hadoop-svc-account:/home/kudu-test:/bin/bash
llama-test:x:1017:1017:hadoop-svc-account:/home/llama-test:/bin/bash
oozie-test:x:1018:1018:hadoop-svc-account:/home/oozie-test:/bin/bash
solr-test:x:1019:1019:hadoop-svc-account:/home/solr-test:/bin/bash
spark-test:x:1020:1020:hadoop-svc-account:/home/spark-test:/bin/bash
sentry-test:x:1021:1021:hadoop-svc-account:/home/sentry-test:/bin/bash
sqoop-test:x:1022:1022:hadoop-svc-account:/home/sqoop-test:/bin/bash
sqoop2-test:x:1023:1023:hadoop-svc-account:/home/sqoop2-test:/bin/bash
zookeeper-test:x:1024:1024:hadoop-svc-account:/home/zookeeper-test:/bin/bash
anonymous-test:x:1025:1025:hadoop-svc-account:/home/anonymous-test:/bin/bash
cmjobuser-test:x:1026:1026:hadoop-svc-account:/home/cmjobuser-test:/bin/bash


hop-isi-c-1# bash ./icu2.sh --dist hwx --zone hdp --append-cluster-name test
Info: Hadoop distribution:  hwx
Info: will put users in zone:  hdp
Info: will add clustername to end of usernames: -test
Info: HDFS root:  /ifs/hdp
Info: passwd file: hdp.passwd
Info: group file: hdp.group
SUCCESS -- Hadoop users created successfully!
Done!
hop-isi-c-1#
hop-isi-c-1# cat hdp.group
# use this file to add to the group file of your clients
hdfs-test:x:1000:
mapred-test:x:1001:
yarn-test:x:1002:
hbase-test:x:1003:
storm-test:x:1004:
falcon-test:x:1005:
tracer-test:x:1006:
tez-test:x:1007:
hive-test:x:1008:
hcat-test:x:1009:
oozie-test:x:1010:
zookeeper-test:x:1011:
ambari-qa-test:x:1012:
flume-test:x:1013:
hue-test:x:1014:
accumulo-test:x:1015:
hadoopqa-test:x:1016:
sqoop-test:x:1017:
spark-test:x:1018:
mahout-test:x:1019:
ranger-test:x:1020:
kms-test:x:1021:
atlas-test:x:1022:
ams-test:x:1023:
kafka-test:x:1024:
zeppelin-test:x:1025:
livy-test:x:1026:
logsearch-test:x:1027:
infra-solr-test:x:1028:
activity_analyzer-test:x:1029:
activity_explorer-test:x:1030:
HTTP-test:x:1031:
knox-test:x:1032:
ambari-server-test:x:1033:
anonymous-test:x:1034:
root-test:x:1035:
admin-test:x:1036:
hadoop-test:x:1037:,hdfs-test,mapred-test,yarn-test,hbase-test,storm-test,falcon-test,tracer-test,tez-test,hive-test,hcat-test,oozie-test,zookeeper-test,ambari-qa-test,flume-test,hue-test,accumulo-test,hadoopqa-test,sqoop-test,spark-test,mahout-test,ranger-test,kms-test,atlas-test,ams-test,kafka-test,zeppelin-test,livy-test,logsearch-test,infra-solr-test,activity_analyzer-test,activity_explorer-test,HTTP-test,knox-test,ambari-server-test
hop-isi-c-1# cat hdp.passwd
# use this file to add to the passwd file of your clients
hdfs-test:x:1000:1000:hadoop-svc-account:/home/hdfs-test:/bin/bash
mapred-test:x:1001:1001:hadoop-svc-account:/home/mapred-test:/bin/bash
yarn-test:x:1002:1002:hadoop-svc-account:/home/yarn-test:/bin/bash
hbase-test:x:1003:1003:hadoop-svc-account:/home/hbase-test:/bin/bash
storm-test:x:1004:1004:hadoop-svc-account:/home/storm-test:/bin/bash
falcon-test:x:1005:1005:hadoop-svc-account:/home/falcon-test:/bin/bash
tracer-test:x:1006:1006:hadoop-svc-account:/home/tracer-test:/bin/bash
tez-test:x:1007:1007:hadoop-svc-account:/home/tez-test:/bin/bash
hive-test:x:1008:1008:hadoop-svc-account:/home/hive-test:/bin/bash
hcat-test:x:1009:1009:hadoop-svc-account:/home/hcat-test:/bin/bash
oozie-test:x:1010:1010:hadoop-svc-account:/home/oozie-test:/bin/bash
zookeeper-test:x:1011:1011:hadoop-svc-account:/home/zookeeper-test:/bin/bash
ambari-qa-test:x:1012:1012:hadoop-svc-account:/home/ambari-qa-test:/bin/bash
flume-test:x:1013:1013:hadoop-svc-account:/home/flume-test:/bin/bash
hue-test:x:1014:1014:hadoop-svc-account:/home/hue-test:/bin/bash
accumulo-test:x:1015:1015:hadoop-svc-account:/home/accumulo-test:/bin/bash
hadoopqa-test:x:1016:1016:hadoop-svc-account:/home/hadoopqa-test:/bin/bash
sqoop-test:x:1017:1017:hadoop-svc-account:/home/sqoop-test:/bin/bash
spark-test:x:1018:1018:hadoop-svc-account:/home/spark-test:/bin/bash
mahout-test:x:1019:1019:hadoop-svc-account:/home/mahout-test:/bin/bash
ranger-test:x:1020:1020:hadoop-svc-account:/home/ranger-test:/bin/bash
kms-test:x:1021:1021:hadoop-svc-account:/home/kms-test:/bin/bash
atlas-test:x:1022:1022:hadoop-svc-account:/home/atlas-test:/bin/bash
ams-test:x:1023:1023:hadoop-svc-account:/home/ams-test:/bin/bash
kafka-test:x:1024:1024:hadoop-svc-account:/home/kafka-test:/bin/bash
zeppelin-test:x:1025:1025:hadoop-svc-account:/home/zeppelin-test:/bin/bash
livy-test:x:1026:1026:hadoop-svc-account:/home/livy-test:/bin/bash
logsearch-test:x:1027:1027:hadoop-svc-account:/home/logsearch-test:/bin/bash
infra-solr-test:x:1028:1028:hadoop-svc-account:/home/infra-solr-test:/bin/bash
activity_analyzer-test:x:1029:1029:hadoop-svc-account:/home/activity_analyzer-test:/bin/bash
activity_explorer-test:x:1030:1030:hadoop-svc-account:/home/activity_explorer-test:/bin/bash
HTTP-test:x:1031:1031:hadoop-svc-account:/home/HTTP-test:/bin/bash
knox-test:x:1032:1032:hadoop-svc-account:/home/knox-test:/bin/bash
ambari-server-test:x:1033:1033:hadoop-svc-account:/home/ambari-server-test:/bin/bash
anonymous-test:x:1034:1034:hadoop-svc-account:/home/anonymous-test:/bin/bash
root-test:x:1035:1035:hadoop-svc-account:/home/root-test:/bin/bash
admin-test:x:1036:1036:hadoop-svc-account:/home/admin-test:/bin/bash


hop-isi-c-1# bash ./icu2.sh --dist bi --zone bi --append-cluster-name test
Info: Hadoop distribution:  bi
Info: will put users in zone:  bi
Info: will add clustername to end of usernames: -test
Info: HDFS root:  /ifs/bi
Info: passwd file: bi.passwd
Info: group file: bi.group
SUCCESS -- Hadoop users created successfully!
Done!
hop-isi-c-1#
hop-isi-c-1# cat bi.group
# use this file to add to the group file of your clients
hdfs-test:x:1000:
mapred-test:x:1001:
yarn-test:x:1002:
hbase-test:x:1003:
storm-test:x:1004:
falcon-test:x:1005:
tracer-test:x:1006:
hive-test:x:1007:
oozie-test:x:1009:
zookeeper-test:x:1010:
ambari-qa-test:x:1011:
flume-test:x:1012:
hue-test:x:1013:
accumulo-test:x:1014:
hadoopqa-test:x:1015:
sqoop-test:x:1016:
spark-test:x:1017:
mahout-test:x:1018:
ranger-test:x:1019:
kms-test:x:1020:
atlas-test:x:1021:
ams-test:x:1022:
kafka-test:x:1023:
zeppelin-test:x:1024:
livy-test:x:1025:
logsearch-test:x:1026:
infra-solr-test:x:1027:
acctivity_analyzer-test:x:1028:
activity_explorer-test:x:1029:
HTTP-test:x:1030:
ambari-server-test:x:1032:
uiuser-test:x:1033:
dsmadmin-test:x:1034:
bigsheets-test:x:1035:
rrdcached-test:x:1036:
bigsql-test:x:1037:
tauser-test:x:1038:
bigr-test:x:1039:
solr-test:x:1040:
bighome-test:x:1041:
anonymous-test:x:1042:
root-test:x:1043:
admin-test:x:1044:
hadoop-test:x:1045:,hdfs-test,mapred-test,yarn-test,hbase-test,storm-test,falcon-test,tracer-test,hive-test,hcat-test,oozie-test,zookeeper-test,ambari-qa-test,flume-test,hue-test,accumulo-test,hadoopqa-test,sqoop-test,spark-test,mahout-test,ranger-test,kms-test,atlas-test,ams-test,kafka-test,zeppelin-test,livy-test,logsearch-test,infra-solr-test,acctivity_analyzer-test,activity_explorer-test,HTTP-test,knox-test,ambari-server-test,uiuser-test,dsmadmin-test,bigsheets-test,rrdcached-test,bigsql-test,tauser-test,bigr-test,solr-test,bighome-test
hcat-test:x:1008:,hive-test
knox-test:x:1031:,kafka-test
hop-isi-c-1# cat bi.passwd
# use this file to add to the passwd file of your clients
hdfs-test:x:1000:1000:hadoop-svc-account:/home/hdfs-test:/bin/bash
mapred-test:x:1001:1001:hadoop-svc-account:/home/mapred-test:/bin/bash
yarn-test:x:1002:1002:hadoop-svc-account:/home/yarn-test:/bin/bash
hbase-test:x:1003:1003:hadoop-svc-account:/home/hbase-test:/bin/bash
storm-test:x:1004:1004:hadoop-svc-account:/home/storm-test:/bin/bash
falcon-test:x:1005:1005:hadoop-svc-account:/home/falcon-test:/bin/bash
tracer-test:x:1006:1006:hadoop-svc-account:/home/tracer-test:/bin/bash
hive-test:x:1007:1007:hadoop-svc-account:/home/hive-test:/bin/bash
hcat-test:x:1008:1008:hadoop-svc-account:/home/hcat-test:/bin/bash
oozie-test:x:1009:1009:hadoop-svc-account:/home/oozie-test:/bin/bash
zookeeper-test:x:1010:1010:hadoop-svc-account:/home/zookeeper-test:/bin/bash
ambari-qa-test:x:1011:1011:hadoop-svc-account:/home/ambari-qa-test:/bin/bash
flume-test:x:1012:1012:hadoop-svc-account:/home/flume-test:/bin/bash
hue-test:x:1013:1013:hadoop-svc-account:/home/hue-test:/bin/bash
accumulo-test:x:1014:1014:hadoop-svc-account:/home/accumulo-test:/bin/bash
hadoopqa-test:x:1015:1015:hadoop-svc-account:/home/hadoopqa-test:/bin/bash
sqoop-test:x:1016:1016:hadoop-svc-account:/home/sqoop-test:/bin/bash
spark-test:x:1017:1017:hadoop-svc-account:/home/spark-test:/bin/bash
mahout-test:x:1018:1018:hadoop-svc-account:/home/mahout-test:/bin/bash
ranger-test:x:1019:1019:hadoop-svc-account:/home/ranger-test:/bin/bash
kms-test:x:1020:1020:hadoop-svc-account:/home/kms-test:/bin/bash
atlas-test:x:1021:1021:hadoop-svc-account:/home/atlas-test:/bin/bash
ams-test:x:1022:1022:hadoop-svc-account:/home/ams-test:/bin/bash
kafka-test:x:1023:1023:hadoop-svc-account:/home/kafka-test:/bin/bash
zeppelin-test:x:1024:1024:hadoop-svc-account:/home/zeppelin-test:/bin/bash
livy-test:x:1025:1025:hadoop-svc-account:/home/livy-test:/bin/bash
logsearch-test:x:1026:1026:hadoop-svc-account:/home/logsearch-test:/bin/bash
infra-solr-test:x:1027:1027:hadoop-svc-account:/home/infra-solr-test:/bin/bash
acctivity_analyzer-test:x:1028:1028:hadoop-svc-account:/home/acctivity_analyzer-test:/bin/bash
activity_explorer-test:x:1029:1029:hadoop-svc-account:/home/activity_explorer-test:/bin/bash
HTTP-test:x:1030:1030:hadoop-svc-account:/home/HTTP-test:/bin/bash
knox-test:x:1031:1031:hadoop-svc-account:/home/knox-test:/bin/bash
ambari-server-test:x:1032:1032:hadoop-svc-account:/home/ambari-server-test:/bin/bash
uiuser-test:x:1033:1033:hadoop-svc-account:/home/uiuser-test:/bin/bash
dsmadmin-test:x:1034:1034:hadoop-svc-account:/home/dsmadmin-test:/bin/bash
bigsheets-test:x:1035:1035:hadoop-svc-account:/home/bigsheets-test:/bin/bash
rrdcached-test:x:1036:1036:hadoop-svc-account:/home/rrdcached-test:/bin/bash
bigsql-test:x:1037:1037:hadoop-svc-account:/home/bigsql-test:/bin/bash
tauser-test:x:1038:1038:hadoop-svc-account:/home/tauser-test:/bin/bash
bigr-test:x:1039:1039:hadoop-svc-account:/home/bigr-test:/bin/bash
solr-test:x:1040:1040:hadoop-svc-account:/home/solr-test:/bin/bash
bighome-test:x:1041:1041:hadoop-svc-account:/home/bighome-test:/bin/bash
anonymous-test:x:1042:1042:hadoop-svc-account:/home/anonymous-test:/bin/bash
root-test:x:1043:1043:hadoop-svc-account:/home/root-test:/bin/bash
admin-test:x:1044:1044:hadoop-svc-account:/home/admin-test:/bin/bash
```
