### PR TITLE
Update isilon_create_users.sh

### DIFF
--- a/isilon_create_users.sh
+++ b/isilon_create_users.sh
@@ -260,7 +260,7 @@ for group in $SUPER_GROUPS; do
         user="$user$CLUSTER_NAME"
         isi auth groups modify $group --add-user $user --zone $ZONE
         [ $? -ne 0 ] && addError "Could not add user $user to $group group in zone $ZONE"
-        sprgrp="$sprgrp,$user"
+        sprgrp="$sprgrp$user,"
     done
     sed -i .bak /$group/d $grpfile
     echo $sprgrp | cat >> $grpfile
@@ -290,14 +290,18 @@ case "$DIST" in
 
         #Set some varliables to take these special case group assignments to the group file
         sqp=`grep sqoop$CLUSTER_NAME $grpfile`
+        sqp2=`grep sqoop2$CLUSTER_NAME: $grpfile`
         hve=`grep hive$CLUSTER_NAME $grpfile`
 
         #manipulate the group file for special cases
         sed -i .bak /$sqp/d $grpfile
-        echo "$sqp,sqoop2$CLUSTER_NAME" | cat >> $grpfile
+        sed -i .bak /$sqp2/d $grpfile
+        echo "$sqp""sqoop2$CLUSTER_NAME" | cat >> $grpfile
         [ $? -ne 0 ] && addError "Could not add user sqoop2$CLUSTER_NAME to sqoop$CLUSTER_NAME group in $grpfile"
+        echo "$sqp2""sqoop$CLUSTER_NAME" | cat >> $grpfile
+        [ $? -ne 0 ] && addError "Could not add user sqoop$CLUSTER_NAME to sqoop$CLUSTER_NAME group in $grpfile"
         sed -i .bak /$hve/d $grpfile
-        echo "$hve,impala$CLUSTER_NAME" | cat >> $grpfile
+        echo "$hve""impala$CLUSTER_NAME" | cat >> $grpfile
         [ $? -ne 0 ] && addError "Could not add user impala$CLUSTER_NAME to hive$CLUSTER_NAME group in $grpfile"
         ;;
     "bi")
@@ -307,7 +311,6 @@ case "$DIST" in
         sed -i .bak /$hct/d $grpfile
         echo "$hct,hive$CLUSTER_NAME" | cat >> $grpfile
         [ $? -ne 0 ] && addError "Could not add user hive$CLUSTER_NAME to hcat$CLUSTER_NAME group in $grpfile"
-
         isi auth groups modify knox$CLUSTER_NAME --add-user kafka$CLUSTER_NAME --zone $ZONE
         [ $? -ne 0 ] && addError "Could not add user kafka$CLUSTER_NAME to knox$CLUSTER_NAME group in zone $ZONE"
         knx=`grep knox$CLUSTER_NAME: $grpfile`


### PR DESCRIPTION
Fixed script to address sqoop issue and removed initial "," inserted to group file.

# bash ./isilon_create_users.sh --dist hwx --zone test2
Info: Hadoop distribution:  hwx
Info: will put users in zone:  test2
Info: HDFS root:  /ifs/test2
Info: passwd file: test2.passwd
Info: group file: test2.group
SUCCESS -- Hadoop users created successfully!
Done!

# bash ./isilon_create_users.sh --dist hwx --zone test --append-cluster-name hdp25
Info: Hadoop distribution:  hwx
Info: will put users in zone:  test
Info: will add clustername to end of usernames: -hdp25
Info: HDFS root:  /ifs/test
Info: passwd file: test.passwd
Info: group file: test.group
SUCCESS -- Hadoop users created successfully!
Done!

1# less test.group
# use this file to add to the group file of your clients
hdfs-hdp25:x:1000:
mapred-hdp25:x:1001:
yarn-hdp25:x:1002:
hbase-hdp25:x:1003:
storm-hdp25:x:1004:
falcon-hdp25:x:1005:
tracer-hdp25:x:1006:
tez-hdp25:x:1007:
hive-hdp25:x:1008:
hcat-hdp25:x:1009:
oozie-hdp25:x:1010:
zookeeper-hdp25:x:1011:
ambari-qa-hdp25:x:1012:
flume-hdp25:x:1013:
hue-hdp25:x:1014:
accumulo-hdp25:x:1015:
hadoopqa-hdp25:x:1016:
sqoop-hdp25:x:1017:
spark-hdp25:x:1018:
mahout-hdp25:x:1019:
ranger-hdp25:x:1020:
kms-hdp25:x:1021:
atlas-hdp25:x:1022:
ams-hdp25:x:1023:
kafka-hdp25:x:1024:
zeppelin-hdp25:x:1025:
livy-hdp25:x:1026:
logsearch-hdp25:x:1027:
infra-solr-hdp25:x:1028:
activity_analyzer-hdp25:x:1029:
activity_explorer-hdp25:x:1030:
HTTP-hdp25:x:1031:
knox-hdp25:x:1032:
ambari-server-hdp25:x:1033:
anonymous-hdp25:x:1034:
admin-hdp25:x:1035:
hadoop-hdp25:x:1036:hdfs-hdp25,mapred-hdp25,yarn-hdp25,hbase-hdp25,storm-hdp25,falcon-hdp25,tracer-hdp25,tez-hdp25,hive-hdp25,hcat-hdp25,oozie-hdp25,zookeeper-hdp25,ambari-qa-hdp25,flume-hdp25,hue-hdp25,accumulo-hdp25,hadoopqa-hdp25,sqoop-hdp25,spark-hdp25,mahout-hdp25,ranger-hdp25,kms-hdp25,atlas-hdp25,ams-hdp25,kafka-hdp25,zeppelin-hdp25,livy-hdp25,logsearch-hdp25,infra-solr-hdp25,activity_analyzer-hdp25,activity_explorer-hdp25,HTTP-hdp25,knox-hdp25,ambari-server-hdp25,
hop-isi-c-1# less test.passwd
# use this file to add to the passwd file of your clients
hdfs-hdp25:x:1000:1000:hadoop-svc-account:/home/hdfs-hdp25:/bin/bash
mapred-hdp25:x:1001:1001:hadoop-svc-account:/home/mapred-hdp25:/bin/bash
yarn-hdp25:x:1002:1002:hadoop-svc-account:/home/yarn-hdp25:/bin/bash
hbase-hdp25:x:1003:1003:hadoop-svc-account:/home/hbase-hdp25:/bin/bash
storm-hdp25:x:1004:1004:hadoop-svc-account:/home/storm-hdp25:/bin/bash
falcon-hdp25:x:1005:1005:hadoop-svc-account:/home/falcon-hdp25:/bin/bash
tracer-hdp25:x:1006:1006:hadoop-svc-account:/home/tracer-hdp25:/bin/bash
tez-hdp25:x:1007:1007:hadoop-svc-account:/home/tez-hdp25:/bin/bash
hive-hdp25:x:1008:1008:hadoop-svc-account:/home/hive-hdp25:/bin/bash
hcat-hdp25:x:1009:1009:hadoop-svc-account:/home/hcat-hdp25:/bin/bash
oozie-hdp25:x:1010:1010:hadoop-svc-account:/home/oozie-hdp25:/bin/bash
zookeeper-hdp25:x:1011:1011:hadoop-svc-account:/home/zookeeper-hdp25:/bin/bash
ambari-qa-hdp25:x:1012:1012:hadoop-svc-account:/home/ambari-qa-hdp25:/bin/bash
flume-hdp25:x:1013:1013:hadoop-svc-account:/home/flume-hdp25:/bin/bash
hue-hdp25:x:1014:1014:hadoop-svc-account:/home/hue-hdp25:/bin/bash
accumulo-hdp25:x:1015:1015:hadoop-svc-account:/home/accumulo-hdp25:/bin/bash
hadoopqa-hdp25:x:1016:1016:hadoop-svc-account:/home/hadoopqa-hdp25:/bin/bash
sqoop-hdp25:x:1017:1017:hadoop-svc-account:/home/sqoop-hdp25:/bin/bash
spark-hdp25:x:1018:1018:hadoop-svc-account:/home/spark-hdp25:/bin/bash
mahout-hdp25:x:1019:1019:hadoop-svc-account:/home/mahout-hdp25:/bin/bash
ranger-hdp25:x:1020:1020:hadoop-svc-account:/home/ranger-hdp25:/bin/bash
kms-hdp25:x:1021:1021:hadoop-svc-account:/home/kms-hdp25:/bin/bash
atlas-hdp25:x:1022:1022:hadoop-svc-account:/home/atlas-hdp25:/bin/bash
ams-hdp25:x:1023:1023:hadoop-svc-account:/home/ams-hdp25:/bin/bash
kafka-hdp25:x:1024:1024:hadoop-svc-account:/home/kafka-hdp25:/bin/bash
zeppelin-hdp25:x:1025:1025:hadoop-svc-account:/home/zeppelin-hdp25:/bin/bash
livy-hdp25:x:1026:1026:hadoop-svc-account:/home/livy-hdp25:/bin/bash
logsearch-hdp25:x:1027:1027:hadoop-svc-account:/home/logsearch-hdp25:/bin/bash
infra-solr-hdp25:x:1028:1028:hadoop-svc-account:/home/infra-solr-hdp25:/bin/bash
activity_analyzer-hdp25:x:1029:1029:hadoop-svc-account:/home/activity_analyzer-hdp25:/bin/bash
activity_explorer-hdp25:x:1030:1030:hadoop-svc-account:/home/activity_explorer-hdp25:/bin/bash
HTTP-hdp25:x:1031:1031:hadoop-svc-account:/home/HTTP-hdp25:/bin/bash
knox-hdp25:x:1032:1032:hadoop-svc-account:/home/knox-hdp25:/bin/bash
ambari-server-hdp25:x:1033:1033:hadoop-svc-account:/home/ambari-server-hdp25:/bin/bash
anonymous-hdp25:x:1034:1034:hadoop-svc-account:/home/anonymous-hdp25:/bin/bash
admin-hdp25:x:1035:1035:hadoop-svc-account:/home/admin-hdp25:/bin/bash

# less test2.group
# use this file to add to the group file of your clients
hdfs:x:1000:
mapred:x:1001:
yarn:x:1002:
hbase:x:1003:
storm:x:1004:
falcon:x:1005:
tracer:x:1006:
tez:x:1007:
hive:x:1008:
hcat:x:1009:
oozie:x:1010:
zookeeper:x:1011:
ambari-qa:x:1012:
flume:x:1013:
hue:x:1014:
accumulo:x:1015:
sqoop:x:1017:
spark:x:1018:
mahout:x:1019:
ranger:x:1020:
kms:x:1021:
atlas:x:1022:
ams:x:1023:
kafka:x:1024:
zeppelin:x:1025:
livy:x:1026:
logsearch:x:1027:
infra-solr:x:1028:
activity_analyzer:x:1029:
activity_explorer:x:1030:
HTTP:x:1031:
knox:x:1032:
ambari-server:x:1033:
anonymous:x:1034:
admin:x:1035:
hadoopqa:x:1016: hadoop:x:1036:hdfs,mapred,yarn,hbase,storm,falcon,tracer,tez,hive,hcat,oozie,zookeeper,ambari-qa,flume,hue,accumulo,hadoopqa,sqoop,spark,mahout,ranger,kms,atlas,ams,kafka,zeppelin,livy,logsearch,infra-solr,activity_analyzer,activity_explorer,HTTP,knox,ambari-server,
hop-isi-c-1# less test.group
# use this file to add to the group file of your clients
hdfs-hdp25:x:1000:
mapred-hdp25:x:1001:
yarn-hdp25:x:1002:
hbase-hdp25:x:1003:
storm-hdp25:x:1004:
falcon-hdp25:x:1005:
tracer-hdp25:x:1006:
tez-hdp25:x:1007:
hive-hdp25:x:1008:
hcat-hdp25:x:1009:
oozie-hdp25:x:1010:
zookeeper-hdp25:x:1011:
ambari-qa-hdp25:x:1012:
flume-hdp25:x:1013:
hue-hdp25:x:1014:
accumulo-hdp25:x:1015:
hadoopqa-hdp25:x:1016:
sqoop-hdp25:x:1017:
spark-hdp25:x:1018:
mahout-hdp25:x:1019:
ranger-hdp25:x:1020:
kms-hdp25:x:1021:
atlas-hdp25:x:1022:
ams-hdp25:x:1023:
kafka-hdp25:x:1024:
zeppelin-hdp25:x:1025:
livy-hdp25:x:1026:
logsearch-hdp25:x:1027:
infra-solr-hdp25:x:1028:
activity_analyzer-hdp25:x:1029:
activity_explorer-hdp25:x:1030:
HTTP-hdp25:x:1031:
knox-hdp25:x:1032:
ambari-server-hdp25:x:1033:
anonymous-hdp25:x:1034:
admin-hdp25:x:1035:
hadoop-hdp25:x:1036:hdfs-hdp25,mapred-hdp25,yarn-hdp25,hbase-hdp25,storm-hdp25,falcon-hdp25,tracer-hdp25,tez-hdp25,hive-hdp25,hcat-hdp25,oozie-hdp25,zookeeper-hdp25,ambari-qa-hdp25,flume-hdp25,hue-hdp25,accumulo-hdp25,hadoopqa-hdp25,sqoop-hdp25,spark-hdp25,mahout-hdp25,ranger-hdp25,kms-hdp25,atlas-hdp25,ams-hdp25,kafka-hdp25,zeppelin-hdp25,livy-hdp25,logsearch-hdp25,infra-solr-hdp25,activity_analyzer-hdp25,activity_explorer-hdp25,HTTP-hdp25,knox-hdp25,ambari-server-hdp25,
