### PR TITLE
Fix several issues in user and directory scripts

### DIFF
--- a/isilon_create_directories.sh
+++ b/isilon_create_directories.sh
@@ -125,11 +125,11 @@ while [ "z$1" != "z" ] ; do
              echo "Info: will use users in zone:  $ZONE"
              ;;
       "--fixperm")
-             echo "Info: will fix permissions and owners on existing directories created by this script."
+             echo "Info: fix permissions and ownership if directories already exist."
              FIXPERM="y"
              ;;
       "--posix-only")
-             echo "Info: will remove all existing permissions, including ACEs, before setting POSIX permissions."
+             echo "Info: remove all existing permissions, including ACEs, before setting POSIX permissions."
              POSIX="y"
              ;;
       "--verbose")
@@ -304,7 +304,7 @@ for direntry in ${dirList[*]}; do
       # echo "DEBUG:  fixing directory perm $ifspath"
       fixperm $ifspath ${specs[2]} ${specs[3]} ${specs[1]}
    else
-      warn "Directory $ifspath exists but no --fixperm not specified"
+      warn "Directory $ifspath exists. To set expected permissions use the --fixperm flag"
    fi
 
 done

--- a/isilon_create_directories.sh
+++ b/isilon_create_directories.sh
@@ -172,7 +172,6 @@ case "$DIST" in
             "/user/spark#751#spark#spark" \
             "/user/spark/applicationHistory#1777#spark#spark" \
             "/user/sqoop2#775#sqoop2#sqoop" \
-            "/solr#775#solr#solr" \
         )
         ;;
     "hwx")

--- a/isilon_create_directories.sh
+++ b/isilon_create_directories.sh
@@ -150,11 +150,11 @@ done
 
 declare -a dirList
 
+# Per-distribution list of folders with permissions and owners
 case "$DIST" in
     "cdh")
         # Format is: dirname#perm#owner#group
         dirList=(\
-            "/#755#hdfs#hadoop" \
             "/hbase#755#hbase#hbase" \
             "/solr#775#solr#solr" \
             "/tmp#1777#hdfs#supergroup" \
@@ -178,7 +178,6 @@ case "$DIST" in
  	# Format is: dirname#perm#owner#group
 	# The directory list below is good thru HDP 2.4
         dirList=(\
-            "/#755#hdfs#hadoop" \
             "/app-logs#777#yarn#hadoop" \
             "/app-logs/ambari-qa#770#ambari-qa#hadoop" \
             "/app-logs/ambari-qa/logs#770#ambari-qa#hadoop" \
@@ -211,7 +210,6 @@ case "$DIST" in
  	# Format is: dirname#perm#owner#group
 	#The directory list is good thru IBM BI v 4.2
         dirList=(\
-            "/#755#hdfs#hadoop" \
             "/tmp#1777#hdfs#hadoop" \
             "/tmp/hive#777#ambari-qa#hadoop"
             "/user#755#hdfs#hadoop" \
@@ -272,6 +270,9 @@ if [ "$VERBOSE" == "y" ] ; then
 fi
 
 banner "Creates Hadoop directory structure on Isilon system HDFS."
+
+# Set permissions on HDFS root
+fixperm $HDFSROOT "hdfs$CLUSTER_NAME" "hadoop$CLUSTER_NAME" "755"
 
 prefix=0
 # Cycle through directory entries comparing owner, group, perm

--- a/isilon_create_users.sh
+++ b/isilon_create_users.sh
@@ -245,7 +245,7 @@ for user in $REQUIRED_USERS; do
        user=$(getUserFromUid $uid $ZONE)
        addError "UID $uid already in use by user $user in zone $ZONE"
     else
-       isi auth users create $user --uid $uid --primary-group $user --zone $ZONE --provider local --home-directory $HDFSROOT/user/$user
+       isi auth users create $user --uid $uid --primary-group $user --zone $ZONE --provider local
        [ $? -ne 0 ] && addError "Could not create user $user with uid $uid in zone $ZONE"
        gid=$(getGidFromGroup $user $ZONE)
        echo "$user:x:$uid:$gid:hadoop-svc-account:/home/$user:/bin/bash" | cat >> $passwdfile

--- a/isilon_create_users.sh
+++ b/isilon_create_users.sh
@@ -167,6 +167,9 @@ case "$DIST" in
         SUPER_USERS="hdfs mapred yarn HTTP hbase"
         SUPER_GROUPS="hadoop supergroup"
         REQUIRED_USERS="$SUPER_USERS hive impala hue cloudera-scm accumulo flume httpfs apache kafka kms keytrustee kudu llama oozie solr spark sentry sqoop sqoop2 zookeeper anonymous cmjobuser"
+        if [ "$ZONE" != "System" ]; then
+          REQUIRED_USERS="$REQUIRED_USERS admin"
+        fi
         REQUIRED_GROUPS="$REQUIRED_USERS $SUPER_GROUPS"
         PROXY_SUPER="impala flume hive hue oozie mapred"
         PROXY_USERONLY="HTTP"


### PR DESCRIPTION
Run to confirm previous errors are gone:

```
roket-naver-1# ~/isilon_create_users.sh --dist cdh --zone System
Info: Hadoop distribution:  cdh
Info: will put users in zone:  System
Info: HDFS root:  /ifs/hdfs-root
Info: passwd file: System.passwd
Info: group file: System.group
SUCCESS -- Hadoop users created successfully!
Done!
roket-naver-1# ~/isilon_create_directories.sh --dist cdh --zone System
Info: Hadoop distribution:  cdh
Info: will use users in zone:  System
Info: HDFS root dir is /ifs/hdfs-root
##################################################################################
## Creates Hadoop directory structure on Isilon system HDFS.
##################################################################################
DEBUG: specs dirname /hbase; perm 755; owner hbase; group hbase
DEBUG: specs dirname /solr; perm 775; owner solr; group solr
DEBUG: specs dirname /tmp; perm 1777; owner hdfs; group supergroup
DEBUG: specs dirname /tmp/logs; perm 1777; owner mapred; group hadoop
DEBUG: specs dirname /tmp/hive; perm 777; owner hive; group supergroup
DEBUG: specs dirname /user; perm 755; owner hdfs; group supergroup
DEBUG: specs dirname /user/history; perm 777; owner mapred; group hadoop
DEBUG: specs dirname /user/hive; perm 775; owner hive; group hive
DEBUG: specs dirname /user/hive/warehouse; perm 1777; owner hive; group hive
DEBUG: specs dirname /user/hue; perm 755; owner hue; group hue
DEBUG: specs dirname /user/hue/.cloudera_manager_hive_metastore_canary; perm 777; owner hue; group hue
DEBUG: specs dirname /user/impala; perm 775; owner impala; group impala
DEBUG: specs dirname /user/oozie; perm 775; owner oozie; group oozie
DEBUG: specs dirname /user/flume; perm 775; owner flume; group flume
DEBUG: specs dirname /user/spark; perm 751; owner spark; group spark
DEBUG: specs dirname /user/spark/applicationHistory; perm 1777; owner spark; group spark
DEBUG: specs dirname /user/sqoop2; perm 775; owner sqoop2; group sqoop
SUCCESS -- Hadoop admin directory structure exists and has correct ownership and permissions
Done!
roket-naver-1# ls -al /ifs/hdfs-root
total 14
drwxr-xr-x     6 hdfs   hadoop       88 Aug  3 16:52 .
drwxrwxrwx     6 root   wheel       100 Aug  3 07:34 ..
drwxr-xr-x     2 hbase  hbase         0 Aug  3 16:52 hbase
drwxrwxr-x     2 solr   solr          0 Aug  3 16:52 solr
drwxrwxrwt     4 hdfs   supergroup   44 Aug  3 16:52 tmp
drwxr-xr-x    10 hdfs   supergroup  185 Aug  3 16:52 user
```