### PR TITLE
Update isilon_create_directories.sh

### DIFF
--- a/isilon_create_directories.sh
+++ b/isilon_create_directories.sh
@@ -202,6 +202,7 @@ case "$DIST" in
             "/user/hive#700#hive#hdfs" \
             "/user/hue#755#hue#hue" \
             "/user/oozie#775#oozie#hdfs" \
+	    "/user/anonymous#775#hdfs#hdfs" \
             "/user/yarn#755#yarn#hdfs" \
             "/system/yarn/node-labels#700#yarn#hadoop" \
         )


### PR DESCRIPTION
Added the creation of anonymous user directory as it is needed by Hive when using Isilon for HDFS Tiered Storage with a DAS Cluster.