### PR TITLE
/app-logs should have sticky bit set.

### DIFF
--- a/isilon_create_directories.sh
+++ b/isilon_create_directories.sh
@@ -179,7 +179,7 @@ case "$DIST" in
         # Format is: dirname#perm#owner#group
         # The directory list below is good thru HDP 2.4
         dirList=(\
-            "/app-logs#777#yarn#hadoop" \
+            "/app-logs#1777#yarn#hadoop" \
             "/app-logs/ambari-qa#770#ambari-qa#hadoop" \
             "/app-logs/ambari-qa/logs#770#ambari-qa#hadoop" \
             "/ats/done#775#yarn#hdfs" \


### PR DESCRIPTION
Without the sticky bit set, you see the following error on worker nodes:

2018-03-07 12:05:57,202 WARN  logaggregation.LogAggregationService (LogAggregationService.java:verifyAndCreateRemoteLogDir(232)) - Remote Root Log Dir [/app-logs] already exist, but with incorrect permissions. Expected: [rwxrwxrwt], Found: [rwxrwxrwx]. The cluster may have problems with multiple users.