### PR TITLE
Added keyadmin, rangerlookup, and yarn-ats users

### DIFF
--- a/isilon_create_users.sh
+++ b/isilon_create_users.sh
@@ -176,7 +176,7 @@ case "$DIST" in
         SMOKE_USER="cloudera-scm"
         ;;
     "hwx")
-        SUPER_USERS="hdfs mapred yarn hbase storm falcon tracer tez hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop spark mahout ranger kms atlas ams kafka zeppelin livy logsearch infra-solr activity_analyzer activity_explorer HTTP knox ambari-server druid"
+        SUPER_USERS="hdfs mapred yarn hbase storm falcon tracer tez hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop spark mahout ranger kms atlas ams kafka zeppelin livy logsearch infra-solr activity_analyzer activity_explorer HTTP knox ambari-server druid keyadmin rangerlookup yarn-ats"
         SUPER_GROUPS="hadoop"
         REQUIRED_USERS="$SUPER_USERS anonymous"
         if [ "$ZONE" != "System" ]; then


### PR DESCRIPTION
These are new users now needed by Hortonworks ADP.