### PR TITLE
Add missing perms to /atsv2

### DIFF
--- a/isilon_create_directories.sh
+++ b/isilon_create_directories.sh
@@ -183,7 +183,7 @@ case "$DIST" in
             "/app-logs/ambari-qa#770#ambari-qa#hadoop" \
             "/app-logs/ambari-qa/logs#770#ambari-qa#hadoop" \
             "/ats/done#775#yarn#hdfs" \
-            "/atsv2#yarn-ats#hadoop" \
+            "/atsv2#755#yarn-ats#hadoop" \
             "/tmp#1777#hdfs#hdfs" \
             "/tmp/hive#777#ambari-qa#hdfs" \
             "/apps#755#hdfs#hadoop" \


### PR DESCRIPTION
Fix #60 

I was immediately able to reproduce the issue:
```
# bash isilon_create_directories.sh --dist hwx --zone System --fixperm
Info: Hadoop distribution:  hwx
Info: will use users in zone:  System
Info: fix permissions and ownership if directories already exist.
Info: HDFS root dir is /ifs
##################################################################################
## Creates Hadoop directory structure on Isilon system HDFS.
##################################################################################
DEBUG: specs dirname /app-logs; perm 1777; owner yarn; group hadoop
DEBUG: specs dirname /app-logs/ambari-qa; perm 770; owner ambari-qa; group hadoop
DEBUG: specs dirname /app-logs/ambari-qa/logs; perm 770; owner ambari-qa; group hadoop
DEBUG: specs dirname /ats/done; perm 775; owner yarn; group hdfs
DEBUG: specs dirname /atsv2; perm yarn-ats; owner hadoop; group
Failed to find user for 'USER:hadoop': No such user
usage: chown [-fghsvx] [-R [-H | -L | -P]] owner[:group] file ...
       chown [-fghvsx] [-R [-H | -L | -P]] :group file ...
usage: chmod [-fhv] [-R [-H | -L | -P]] [-b] mode file ...
       chmod [-fhv] [-R [-H | -L | -P]] [-a | +a | =a] [-i] [-# [n]] ACE file ...
       chmod [-fhv] [-R [-H | -L | -P]] [E | -C | -i | -I | -D | -N] file ...
       chmod [-fhv] [-R [-H | -L | -P]] [-c CONTROL_FLAGS] file ...
DEBUG: specs dirname /tmp; perm 1777; owner hdfs; group hdfs
DEBUG: specs dirname /tmp/hive; perm 777; owner ambari-qa; group hdfs
DEBUG: specs dirname /apps; perm 755; owner hdfs; group hadoop
DEBUG: specs dirname /apps/falcon; perm 777; owner falcon; group hdfs
DEBUG: specs dirname /apps/accumulo/; perm 750; owner accumulo; group hadoop
DEBUG: specs dirname /apps/hbase; perm 755; owner hdfs; group hadoop
DEBUG: specs dirname /apps/hbase/data; perm 775; owner hbase; group hadoop
DEBUG: specs dirname /apps/hbase/staging; perm 711; owner hbase; group hadoop
DEBUG: specs dirname /apps/hive; perm 755; owner hdfs; group hdfs
DEBUG: specs dirname /apps/hive/warehouse; perm 777; owner hive; group hdfs
DEBUG: specs dirname /apps/tez; perm 755; owner tez; group hdfs
DEBUG: specs dirname /apps/webhcat; perm 755; owner hcat; group hdfs
DEBUG: specs dirname /mapred; perm 755; owner mapred; group hadoop
DEBUG: specs dirname /mapred/system; perm 755; owner mapred; group hadoop
DEBUG: specs dirname /user; perm 755; owner hdfs; group hdfs
DEBUG: specs dirname /user/ambari-qa; perm 770; owner ambari-qa; group hdfs
DEBUG: specs dirname /user/hcat; perm 755; owner hcat; group hdfs
DEBUG: specs dirname /user/hdfs; perm 755; owner hdfs; group hdfs
DEBUG: specs dirname /user/hive; perm 700; owner hive; group hdfs
DEBUG: specs dirname /user/hue; perm 755; owner hue; group hue
DEBUG: specs dirname /user/oozie; perm 775; owner oozie; group hdfs
DEBUG: specs dirname /user/yarn; perm 755; owner yarn; group hdfs
DEBUG: specs dirname /system/yarn/node-labels; perm 700; owner yarn; group hadoop
SUCCESS -- Hadoop admin directory structure exists and has correct ownership and permissions
Done!
```
After applying this patch, I reran on the same cluster and did not see the issue again:
```
# bash isilon_create_directories.sh --dist hwx --zone System --fixperm
Info: Hadoop distribution:  hwx
Info: will use users in zone:  System
Info: fix permissions and ownership if directories already exist.
Info: HDFS root dir is /ifs
##################################################################################
## Creates Hadoop directory structure on Isilon system HDFS.
##################################################################################
DEBUG: specs dirname /app-logs; perm 1777; owner yarn; group hadoop
DEBUG: specs dirname /app-logs/ambari-qa; perm 770; owner ambari-qa; group hadoop
DEBUG: specs dirname /app-logs/ambari-qa/logs; perm 770; owner ambari-qa; group hadoop
DEBUG: specs dirname /ats/done; perm 775; owner yarn; group hdfs
DEBUG: specs dirname /atsv2; perm 755; owner yarn-ats; group hadoop
DEBUG: specs dirname /tmp; perm 1777; owner hdfs; group hdfs
DEBUG: specs dirname /tmp/hive; perm 777; owner ambari-qa; group hdfs
DEBUG: specs dirname /apps; perm 755; owner hdfs; group hadoop
DEBUG: specs dirname /apps/falcon; perm 777; owner falcon; group hdfs
DEBUG: specs dirname /apps/accumulo/; perm 750; owner accumulo; group hadoop
DEBUG: specs dirname /apps/hbase; perm 755; owner hdfs; group hadoop
DEBUG: specs dirname /apps/hbase/data; perm 775; owner hbase; group hadoop
DEBUG: specs dirname /apps/hbase/staging; perm 711; owner hbase; group hadoop
DEBUG: specs dirname /apps/hive; perm 755; owner hdfs; group hdfs
DEBUG: specs dirname /apps/hive/warehouse; perm 777; owner hive; group hdfs
DEBUG: specs dirname /apps/tez; perm 755; owner tez; group hdfs
DEBUG: specs dirname /apps/webhcat; perm 755; owner hcat; group hdfs
DEBUG: specs dirname /mapred; perm 755; owner mapred; group hadoop
DEBUG: specs dirname /mapred/system; perm 755; owner mapred; group hadoop
DEBUG: specs dirname /user; perm 755; owner hdfs; group hdfs
DEBUG: specs dirname /user/ambari-qa; perm 770; owner ambari-qa; group hdfs
DEBUG: specs dirname /user/hcat; perm 755; owner hcat; group hdfs
DEBUG: specs dirname /user/hdfs; perm 755; owner hdfs; group hdfs
DEBUG: specs dirname /user/hive; perm 700; owner hive; group hdfs
DEBUG: specs dirname /user/hue; perm 755; owner hue; group hue
DEBUG: specs dirname /user/oozie; perm 775; owner oozie; group hdfs
DEBUG: specs dirname /user/yarn; perm 755; owner yarn; group hdfs
DEBUG: specs dirname /system/yarn/node-labels; perm 700; owner yarn; group hadoop
SUCCESS -- Hadoop admin directory structure exists and has correct ownership and permissions
Done!
```