### PR TITLE
Correct group file handling when adding users

### DIFF
--- a/isilon_create_users.sh
+++ b/isilon_create_users.sh
@@ -257,7 +257,7 @@ done
 
 for group in $SUPER_GROUPS; do
     group="$group$CLUSTER_NAME"
-    sprgrp=`grep $group $grpfile`
+    sprgrp="$(grep "$group:" "$grpfile")"
     [ $? -ne 0 ] && addError "Could not locate entry $group in group file stub $grpfile"
     for user in $SUPER_USERS; do
         user="$user$CLUSTER_NAME"
@@ -265,8 +265,8 @@ for group in $SUPER_GROUPS; do
         [ $? -ne 0 ] && addError "Could not add user $user to $group group in zone $ZONE"
         sprgrp="$sprgrp$user,"
     done
-    sed -i .bak /$group/d $grpfile
-    echo $sprgrp | cat >> $grpfile
+    sed -i .bak "/$group:/d" "$grpfile"
+    echo "$sprgrp" >> "$grpfile"
 done
 # set +x
 


### PR DESCRIPTION
Fix #63 

Before:
```
# tail foo.group
knox:x:1033:
ambari-server:x:1034:
druid:x:1035:
keyadmin:x:1036:
rangerlookup:x:1037:
yarn-ats:x:1038:
gpadmin:x:1039:
anonymous:x:1040:
admin:x:1041:
hadoopqa:x:1017: hadoop:x:1042:hdfs,mapred,yarn,yarn-ats-hbase,hbase,storm,falcon,tracer,tez,hive,hcat,oozie,zookeeper,ambari-qa,flume,hue,accumulo,hadoopqa,sqoop,spark,mahout,ranger,kms,atlas,ams,kafka,zeppelin,livy,logsearch,infra-solr,activity_analyzer,activity_explorer,HTTP,knox,ambari-server,druid,keyadmin,rangerlookup,yarn-ats,gpadmin,
```
- The last line is malformed.
```
# diff foo.group.bak foo.group
19d18
< hadoopqa:x:1017:
44c43
< hadoop:x:1042:
---
> hadoopqa:x:1017: hadoop:x:1042:hdfs,mapred,yarn,yarn-ats-hbase,hbase,storm,falcon,tracer,tez,hive,hcat,oozie,zookeeper,ambari-qa,flume,hue,accumulo,hadoopqa,sqoop,spark,mahout,ranger,kms,atlas,ams,kafka,zeppelin,livy,logsearch,infra-solr,activity_analyzer,activity_explorer,HTTP,knox,ambari-server,druid,keyadmin,rangerlookup,yarn-ats,gpadmin,
```
- Two lines are combined when users are added.
***
After:
```
# tail foo.group
knox:x:1033:
ambari-server:x:1034:
druid:x:1035:
keyadmin:x:1036:
rangerlookup:x:1037:
yarn-ats:x:1038:
gpadmin:x:1039:
anonymous:x:1040:
admin:x:1041:
hadoop:x:1042:hdfs,mapred,yarn,yarn-ats-hbase,hbase,storm,falcon,tracer,tez,hive,hcat,oozie,zookeeper,ambari-qa,flume,hue,accumulo,hadoopqa,sqoop,spark,mahout,ranger,kms,atlas,ams,kafka,zeppelin,livy,logsearch,infra-solr,activity_analyzer,activity_explorer,HTTP,knox,ambari-server,druid,keyadmin,rangerlookup,yarn-ats,gpadmin,
```
```
# diff foo.group.bak foo.group
44c44
< hadoop:x:1042:
---
> hadoop:x:1042:hdfs,mapred,yarn,yarn-ats-hbase,hbase,storm,falcon,tracer,tez,hive,hcat,oozie,zookeeper,ambari-qa,flume,hue,accumulo,hadoopqa,sqoop,spark,mahout,ranger,kms, atlas,ams,kafka,zeppelin,livy,logsearch,infra-solr,activity_analyzer,activity_explorer,HTTP,knox,ambari-server,druid,keyadmin,rangerlookup,yarn-ats,gpadmin,
```