### PR TITLE
Update isilon_create_users.sh

### DIFF
--- a/isilon_create_users.sh
+++ b/isilon_create_users.sh
@@ -245,7 +245,7 @@ for user in $REQUIRED_USERS; do
        user=$(getUserFromUid $uid $ZONE)
        addError "UID $uid already in use by user $user in zone $ZONE"
     else
-       isi auth users create $user --uid $uid --primary-group $user --zone $ZONE --provider local
+       isi auth users create $user --uid $uid --primary-group $user --zone $ZONE --provider local --enabled yes
        [ $? -ne 0 ] && addError "Could not create user $user with uid $uid in zone $ZONE"
        gid=$(getGidFromGroup $user $ZONE)
        echo "$user:x:$uid:$gid:hadoop-svc-account:/home/$user:/bin/bash" | cat >> $passwdfile


### PR DESCRIPTION
Fix #62 

OneFS 8.2 requires local user accounts to be enabled for the account to be used, added switch to enable all the local accounts that are created.

With 8.2 now GA updated to enabled all accounts, don't see any issue with having accounts enabled on any version of OneFS at this time, accounts are still just used for ID's not interactive logon possible.