### PR TITLE
Found the shortage of the users for ambari

### DIFF
--- a/isilon_create_users.sh
+++ b/isilon_create_users.sh
@@ -176,7 +176,7 @@ case "$DIST" in
         SMOKE_USER="cloudera-scm"
         ;;
     "hwx")
-        SUPER_USERS="hdfs mapred yarn yarn-ats-hbase hbase storm falcon tracer tez hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop spark mahout ranger kms atlas ams kafka zeppelin livy logsearch infra-solr activity_analyzer activity_explorer HTTP knox ambari-server druid keyadmin rangerlookup yarn-ats gpadmin nm rm amshbase jhs"
+        SUPER_USERS="hdfs mapred yarn yarn-ats-hbase hbase storm falcon tracer tez hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop spark mahout ranger kms atlas ams kafka zeppelin livy logsearch infra-solr activity_analyzer activity_explorer HTTP knox ambari-server druid keyadmin rangerlookup yarn-ats gpadmin nifi nifiregistry nm rm amshbase jhs"
         SUPER_GROUPS="hadoop"
         REQUIRED_USERS="$SUPER_USERS anonymous"
         if [ "$ZONE" != "System" ]; then

--- a/isilon_create_users.sh
+++ b/isilon_create_users.sh
@@ -176,7 +176,7 @@ case "$DIST" in
         SMOKE_USER="cloudera-scm"
         ;;
     "hwx")
-        SUPER_USERS="hdfs mapred yarn yarn-ats-hbase hbase storm falcon tracer tez hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop spark mahout ranger kms atlas ams kafka zeppelin livy logsearch infra-solr activity_analyzer activity_explorer HTTP knox ambari-server druid keyadmin rangerlookup yarn-ats gpadmin"
+        SUPER_USERS="hdfs mapred yarn yarn-ats-hbase hbase storm falcon tracer tez hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop spark mahout ranger kms atlas ams kafka zeppelin livy logsearch infra-solr activity_analyzer activity_explorer HTTP knox ambari-server druid keyadmin rangerlookup yarn-ats gpadmin rm amshbase jhs"
         SUPER_GROUPS="hadoop"
         REQUIRED_USERS="$SUPER_USERS anonymous"
         if [ "$ZONE" != "System" ]; then

--- a/isilon_create_users.sh
+++ b/isilon_create_users.sh
@@ -176,7 +176,7 @@ case "$DIST" in
         SMOKE_USER="cloudera-scm"
         ;;
     "hwx")
-        SUPER_USERS="hdfs mapred yarn yarn-ats-hbase hbase storm falcon tracer tez hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop spark mahout ranger kms atlas ams kafka zeppelin livy logsearch infra-solr activity_analyzer activity_explorer HTTP knox ambari-server druid keyadmin rangerlookup yarn-ats gpadmin rm amshbase jhs"
+        SUPER_USERS="hdfs mapred yarn yarn-ats-hbase hbase storm falcon tracer tez hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop spark mahout ranger kms atlas ams kafka zeppelin livy logsearch infra-solr activity_analyzer activity_explorer HTTP knox ambari-server druid keyadmin rangerlookup yarn-ats gpadmin nm rm amshbase jhs"
         SUPER_GROUPS="hadoop"
         REQUIRED_USERS="$SUPER_USERS anonymous"
         if [ "$ZONE" != "System" ]; then

--- a/isilon_create_users.sh
+++ b/isilon_create_users.sh
@@ -176,7 +176,7 @@ case "$DIST" in
         SMOKE_USER="cloudera-scm"
         ;;
     "hwx")
-        SUPER_USERS="hdfs mapred yarn yarn-ats-hbase hbase storm falcon tracer tez hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop spark mahout ranger kms atlas ams kafka zeppelin livy logsearch infra-solr activity_analyzer activity_explorer HTTP knox ambari-server druid keyadmin rangerlookup yarn-ats gpadmin nifi nifiregistry nm rm amshbase jhs"
+        SUPER_USERS="hdfs mapred yarn yarn-ats-hbase hbase storm falcon tracer tez hive hcat oozie zookeeper ambari-qa flume hue accumulo hadoopqa sqoop spark mahout ranger kms atlas ams kafka zeppelin livy logsearch infra-solr activity_analyzer activity_explorer HTTP knox ambari-server druid keyadmin rangerlookup yarn-ats gpadmin nm rm amshbase jhs"
         SUPER_GROUPS="hadoop"
         REQUIRED_USERS="$SUPER_USERS anonymous"
         if [ "$ZONE" != "System" ]; then


### PR DESCRIPTION
Added the 3user (rm, amshbase and jhs) to hwx's SUPERUSER in isilon_create_user.sh because these users need to exist when ambari linked to isilon is kerberized.