### PR TITLE
Added needed directory to support YARN in CDH-6.3

### DIFF
--- a/isilon_create_directories.sh
+++ b/isilon_create_directories.sh
@@ -173,6 +173,7 @@ case "$DIST" in
             "/user/spark#751#spark#spark" \
             "/user/spark/applicationHistory#1777#spark#spark" \
             "/user/sqoop2#775#sqoop2#sqoop" \
+            "/user/yarn/mapreduce/mr-framework#755#yarn#hadoop" \
         )
         ;;
     "hwx")

--- a/isilon_create_directories.sh
+++ b/isilon_create_directories.sh
@@ -173,7 +173,7 @@ case "$DIST" in
             "/user/spark#751#spark#spark" \
             "/user/spark/applicationHistory#1777#spark#spark" \
             "/user/sqoop2#775#sqoop2#sqoop" \
-            "/user/yarn/mapreduce/mr-framework#755#yarn#hadoop" \
+            "/user/yarn/#755#yarn#yarn" \
         )
         ;;
     "hwx")


### PR DESCRIPTION
MR framework jars are currently in /user/yarn/mapreduce/mr-framework, added this directory to script as YARN failed to startup without it.  May need to add other service directories in /user/yarn down the road, for now, this was the only core service not starting.