### PR TITLE
Do not raise exception when path already exists

### DIFF
--- a/src/isilon_hadoop_tools/onefs.py
+++ b/src/isilon_hadoop_tools/onefs.py
@@ -288,6 +288,8 @@ class APIError(_BaseAPIError):
     user_not_found_error_format = "Failed to find user for 'USER:{0}': No such user"
     user_unresolvable_error_format = "Could not resolve user {0}"
     zone_not_found_error_format = 'Access Zone "{0}" not found.'
+    dir_path_already_exists_error_format = \
+        'Unable to create directory as requested -- container already exists'
     # pylint: enable=invalid-name
 
     def __str__(self):
@@ -456,6 +458,14 @@ class APIError(_BaseAPIError):
                 lambda error: error['message'] == self.zone_not_found_error_format.format(
                     zone_name,
                 ),
+            )
+        )
+
+    def dir_path_already_exists_error(self):
+        """Returns True if the exception contains a directory path already exist error."""
+        return any(
+            self.filtered_errors(
+                lambda error: error['message'] == self.dir_path_already_exists_error_format,
             )
         )
 


### PR DESCRIPTION
Isi sdk will report error when the path to create already exists.
This change is to cache the error and not raise an exception.

Test Done:

Dir exists:
root@DTRDUCLI587384:~/isilon_hadoop_tools [master *] # venv/bin/isilon_create_directories --zone system --dist hdp --no-verify  --onefs-password a 10.224.15.38
[WARNING] Deploying in the System zone is not recommended.
[INFO] mkdir '/ifs/hdfs_root/'
[WARNING] /ifs/hdfs_root/ already exists.
[INFO] chmod '755' '/ifs/hdfs_root/'
[INFO] chown 'hdfs:hadoop' '/ifs/hdfs_root/'
[INFO] mkdir '/ifs/hdfs_root/app-logs'
[WARNING] /ifs/hdfs_root/app-logs already exists.

Dir does not exist:
root@DTRDUCLI587384:~/isilon_hadoop_tools [master *] # venv/bin/isilon_create_directories --zone system --dist hdp --no-verify  --onefs-password a 10.224.15.38
[WARNING] Deploying in the System zone is not recommended.
[INFO] mkdir '/ifs/hdfs_root/'
[INFO] chmod '755' '/ifs/hdfs_root/'
[INFO] chown 'hdfs:hadoop' '/ifs/hdfs_root/'
[INFO] mkdir '/ifs/hdfs_root/app-logs'
[INFO] chmod '1777' '/ifs/hdfs_root/app-logs'
[INFO] chown 'yarn:hadoop' '/ifs/hdfs_root/app-logs'
[INFO] mkdir '/ifs/hdfs_root/app-logs/ambari-qa'
[INFO] chmod '770' '/ifs/hdfs_root/app-logs/ambari-qa'

Tox:
======================================================== 45 passed, 86 skipped in 6.01 seconds ========================================================
_______________________________________________________________________ summary _______________________________________________________________________
  py27-urllib3121: commands succeeded
  py27-urllib3default: commands succeeded
  py35-urllib3121: commands succeeded
  py35-urllib3default: commands succeeded
  py36-urllib3121: commands succeeded
  py36-urllib3default: commands succeeded
  congratulations :)
root@DTRDUCLI587384:~/isilon_hadoop_tools [master *] 
