### PR TITLE
Use py38 for static testing and deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install: pip install --upgrade pip setuptools wheel
 install: pip install --upgrade tox-travis
 script:
 - tox -- -r a
-- if [ "$TRAVIS_PYTHON_VERSION" = '3.5' ]; then tox -e static; fi
+- if [ "$TRAVIS_PYTHON_VERSION" = '3.8' ]; then tox -e static; fi
 deploy:
   provider: pypi
   user: __token__
@@ -20,5 +20,5 @@ deploy:
     repo: Isilon/isilon_hadoop_tools
     branch: master
     tags: true
-    python: '3.5'
+    python: '3.8'
   skip_existing: true

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands =
 
 [testenv:static]
 
-basepython = python3.5
+basepython = python3.8
 
 deps =
     flake8 ~= 3.7.8

--- a/tox.ini
+++ b/tox.ini
@@ -36,3 +36,13 @@ commands =
 [flake8]
 
 max-line-length = 100
+
+[testenv:publish]
+basepython = python3.8
+passenv = TWINE_*
+deps =
+    build ~= 0.3.0
+    twine ~= 3.4.0
+commands =
+    {envpython} -m build --outdir {distdir} .
+    twine {posargs:check} {distdir}/*


### PR DESCRIPTION
Travis failed to deploy 4.1.0: https://travis-ci.com/github/Isilon/isilon_hadoop_tools/jobs/496947152#L354
```
Installing deploy dependencies
Successfully installed dpl-pypi-1.10.16
1 gem installed
2021-04-08 08:59:44 URL:https://bootstrap.pypa.io/get-pip.py [1927630/1927630] -> "-" [1]
ERROR: This script does not work on Python 3.5 The minimum supported Python version is 3.6. Please use https://bootstrap.pypa.io/pip/3.5/get-pip.py instead.
Couldn't install pip, setuptools, twine or wheel.
failed to deploy
```
So, let's switch to the latest version currently used by the project (py38).