### PR TITLE
Support passowrd setting when creating users

### DIFF
--- a/src/isilon_hadoop_tools/_scripts.py
+++ b/src/isilon_hadoop_tools/_scripts.py
@@ -72,6 +72,12 @@ def isilon_create_users_cli(parser=None):
         type=int,
         default=isilon_hadoop_tools.identities.Creator.default_start_uid,
     )
+    parser.add_argument(
+        '--user-password',
+        help='the password for users created',
+        type=str,
+        default=None,
+    )
     return parser
 
 
@@ -112,6 +118,7 @@ def isilon_create_users(argv=None):
         start_uid=args.start_uid,
         start_gid=args.start_gid,
         script_path=os.path.join(os.getcwd(), name + '.sh'),
+        user_password=args.user_password,
     )
     if args.dry:
         LOGGER.info(DRY_RUN)

--- a/src/isilon_hadoop_tools/identities.py
+++ b/src/isilon_hadoop_tools/identities.py
@@ -66,12 +66,14 @@ class Creator(object):
             start_uid=default_start_uid,
             start_gid=default_start_gid,
             script_path=None,
+            user_password=None,
     ):
         self.onefs = onefs
         self.onefs_zone = onefs_zone
         self._next_uid = start_uid
         self._next_gid = start_gid
         self.script_path = script_path
+        self.user_password = user_password
 
     @property
     def next_gid(self):
@@ -240,6 +242,7 @@ class Creator(object):
                     primary_group_name=primary_group_name,
                     zone=self.onefs_zone,
                     enabled=True,
+                    password=self.user_password,
                 )
                 break
             except isilon_hadoop_tools.onefs.APIError as exc:

--- a/src/isilon_hadoop_tools/onefs.py
+++ b/src/isilon_hadoop_tools/onefs.py
@@ -883,7 +883,7 @@ class BaseClient(object):  # pylint: disable=too-many-public-methods,too-many-in
         self._sdk.AuthApi(self._api_client).create_providers_krb5_item(providers_krb5_item)
 
     @accesses_onefs
-    def create_user(self, name, primary_group_name, uid=None, zone=None, enabled=None):
+    def create_user(self, name, primary_group_name, uid=None, zone=None, enabled=None, password=None):
         """Create a user."""
         group_member_cls = (
             self._sdk.GroupMember
@@ -899,6 +899,7 @@ class BaseClient(object):  # pylint: disable=too-many-public-methods,too-many-in
                     name=primary_group_name,
                 ),
                 uid=uid,
+                password=password,
             ),
             zone=zone or self.default_zone,
         )


### PR DESCRIPTION
Fix #102 

Add an option to set user password when creating users, so that when OneFS asks for mandatory user passwords, user creation could still succeed with Isilon_hadoop_tools.

Now the same password will be set for all created users for simplicity, the administrator could change user passwords after user creation if necessary.

