### PR TITLE
Fix CI builds

### DIFF
--- a/.github/workflows/publication.yml
+++ b/.github/workflows/publication.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.11'
+        python-version: '3.8'
     - run: python -m pip install --upgrade tox-gh-actions
     - env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/publication.yml
+++ b/.github/workflows/publication.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.11'
     - run: python -m pip install --upgrade tox-gh-actions
     - env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8"]
+        python-version: ["2.7", "3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["2.7", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["2.7", "3.7", "3.8"]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,8 @@ tox
 # Run a specific test with Python 2.7, and drop into Pdb if it fails:
 tox -e py27 -- -k test_catches --pdb
 
-# Create a Python 3.5 development environment:
-tox -e py35 --devenv ./venv
+# Create a Python 3.7 development environment:
+tox -e py37 --devenv ./venv
 
 # Run an IHT console_script in that environment:
 venv/bin/isilon_create_users --help

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Tools for Using Hadoop with OneFS
 
 ## Installation
 
-Isilon Hadoop Tools (IHT) currently requires Python 3.5+ and supports OneFS 8+.
+Isilon Hadoop Tools (IHT) currently requires Python 3.7+ and supports OneFS 8+.
 
 - Python support schedules can be found [in the Python Developer's Guide](https://devguide.python.org/#status-of-python-branches).
 - OneFS support schedules can be found in the [Isilon Product Availability Guide](https://support.emc.com/docu45445_Isilon-Product-Availability.pdf).
@@ -20,7 +20,7 @@ Isilon Hadoop Tools (IHT) currently requires Python 3.5+ and supports OneFS 8+.
 <summary>Use <code>pipx</code> to install IHT.</summary>
 <br>
 
-> _`pipx` requires Python 3.6 or later. For other versions or **offline installations**, see Option 2._
+> _`pipx` requires Python 3.7 or later. For other versions or **offline installations**, see Option 2._
 
 1. [Install `pipx`:](https://pipxproject.github.io/pipx/installation/)
 

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,6 @@ setuptools.setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.7.0
 isolated_build = true
-envlist = py{27,35,36,37,38}-urllib3{121,default}
+envlist = py{27,37,38}-urllib3{121,default}
 
 [testenv]
 deps =
@@ -19,8 +19,6 @@ commands =
 [gh-actions]
 python =
     2.7: py27-urllib3{121,default}
-    3.5: py35-urllib3{121,default}
-    3.6: py36-urllib3{121,default}
     3.7: py37-urllib3{121,default}
     3.8: py38-urllib3{121,default}, static, publish
 


### PR DESCRIPTION
Github changed to Ubuntu 22.04 in October 22 as the default for "ubuntu-latest" https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/.
Unfortunately, there is no Python 3.5 or 3.6 for Ubuntu 22.04 for x86 as can be seen here https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json and this means that currently the CI builds are failing.

3.5 & 3.6 are also EOL and pipx requires 3.7 as well (now), that's why I decided to change the minimum system requirements to 3.7. Hope that's fine for you.

I'd like to get this in before my other PRs :)